### PR TITLE
Speed up and remove dependency from secrets in CI

### DIFF
--- a/.github/workflows/deploiement_auto_pg_production.yml
+++ b/.github/workflows/deploiement_auto_pg_production.yml
@@ -83,17 +83,11 @@ jobs:
         source dbt-env/bin/activate
         python -m load --production
 
-  
-    - name: Run dbt seed
+    - name: Run dbt build
       run: |
         source dbt-env/bin/activate
-        dbt seed
+        dbt build --target production
 
-    - name: Run dbt run
-      run: |
-        source dbt-env/bin/activate
-        dbt run --target production
-      
     - name: Generate dbt Documentation
       run: |
         source dbt-env/bin/activate

--- a/.github/workflows/deploiement_auto_pg_production.yml
+++ b/.github/workflows/deploiement_auto_pg_production.yml
@@ -14,12 +14,13 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11.5
+        cache: 'pip'
 
     - name: Create Python virtual environment
       run: python3 -m venv dbt-env
@@ -105,7 +106,7 @@ jobs:
         path: target/*
 
     - name: Checkout new repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: make-open-data/make-open-data-docs
         token: ${{ secrets.PAT }} 

--- a/.github/workflows/deploiement_auto_pg_production.yml
+++ b/.github/workflows/deploiement_auto_pg_production.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Load data from storage to tables in DB
       run: |
         source dbt-env/bin/activate
-        python -m load
+        python -m load --production
 
   
     - name: Run dbt seed

--- a/.github/workflows/deploiement_auto_pg_production.yml
+++ b/.github/workflows/deploiement_auto_pg_production.yml
@@ -12,17 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
-    services:
-      postgres:
-        image: postgis/postgis:12-3.1
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: make_open_data
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
     - name: Check out repository code
       uses: actions/checkout@v2

--- a/.github/workflows/deploiement_manuel_pg_utilisateur.yml
+++ b/.github/workflows/deploiement_manuel_pg_utilisateur.yml
@@ -9,12 +9,13 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11.5
+        cache: 'pip'
 
     - name: Create Python virtual environment
       run: python3 -m venv dbt-env

--- a/.github/workflows/deploiement_manuel_pg_utilisateur.yml
+++ b/.github/workflows/deploiement_manuel_pg_utilisateur.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Load data from storage to tables in DB
       run: |
         source dbt-env/bin/activate
-        python -m load
+        python -m load --production
 
     - name: Run dbt deps
       run: |

--- a/.github/workflows/deploiement_manuel_pg_utilisateur.yml
+++ b/.github/workflows/deploiement_manuel_pg_utilisateur.yml
@@ -79,17 +79,7 @@ jobs:
         source dbt-env/bin/activate
         dbt deps
 
-    - name: Run dbt seed
+    - name: Run dbt build
       run: |
         source dbt-env/bin/activate
-        dbt seed
-
-    - name: Run dbt run
-      run: |
-        source dbt-env/bin/activate
-        dbt run --target production
-
-    - name: Run dbt test
-      run: |
-        source dbt-env/bin/activate
-        dbt test
+        dbt build --target production

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: integration_test
 
+    services:
+      postgres:
+        image: postgis/postgis:16-3.5-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - name: Check out repository code
       uses: actions/checkout@v2
@@ -32,19 +45,13 @@ jobs:
         pip install -r requirements.txt
 
     - name: Set environment variables
-      env: 
-        POSTGRES_DB: ${{ secrets.CI_POSTGRES_DB }}
-        POSTGRES_HOST: ${{ secrets.CI_POSTGRES_HOST }}
-        POSTGRES_PASSWORD: ${{ secrets.CI_POSTGRES_PASSWORD }}
-        POSTGRES_PORT: ${{ secrets.CI_POSTGRES_PORT }}
-        POSTGRES_USER: ${{ secrets.CI_POSTGRES_USER }}
       run: |
         source dbt-env/bin/activate
-        echo "POSTGRES_DB=$POSTGRES_DB" >> $GITHUB_ENV
-        echo "POSTGRES_HOST=$POSTGRES_HOST" >> $GITHUB_ENV
-        echo "POSTGRES_PASSWORD=$POSTGRES_PASSWORD" >> $GITHUB_ENV
-        echo "POSTGRES_PORT=$POSTGRES_PORT" >> $GITHUB_ENV
-        echo "POSTGRES_USER=$POSTGRES_USER" >> $GITHUB_ENV
+        echo "POSTGRES_DB=postgres" >> $GITHUB_ENV
+        echo "POSTGRES_HOST=localhost" >> $GITHUB_ENV
+        echo "POSTGRES_PASSWORD=postgres" >> $GITHUB_ENV
+        echo "POSTGRES_PORT=5432" >> $GITHUB_ENV
+        echo "POSTGRES_USER=postgres" >> $GITHUB_ENV
 
     - name: Install PostGIS extensions
     

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Run dbt run
       run: |
         source dbt-env/bin/activate
-        dbt run
+        dbt run --threads 4
 
     - name: Run dbt test
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -115,9 +115,3 @@ jobs:
       run: |
         source dbt-env/bin/activate
         dbt test
-
-
-    - name: delete "prep" schemas if exists
-      run: |
-        source dbt-env/bin/activate
-        psql postgresql://${{  secrets.CI_POSTGRES_USER  }}:${{  secrets.CI_POSTGRES_PASSWORD  }}@${{  secrets.CI_POSTGRES_HOST  }}:${{  secrets.CI_POSTGRES_PORT  }}/${{  secrets.CI_POSTGRES_DB  }} -c "DROP SCHEMA IF EXISTS prep CASCADE;"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -101,17 +101,7 @@ jobs:
         source dbt-env/bin/activate
         dbt deps
 
-    - name: Run dbt seed
+    - name: Run dbt build
       run: |
         source dbt-env/bin/activate
-        dbt seed
-
-    - name: Run dbt run
-      run: |
-        source dbt-env/bin/activate
-        dbt run --threads 4
-
-    - name: Run dbt test
-      run: |
-        source dbt-env/bin/activate
-        dbt test
+        dbt build --threads 4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,12 +28,13 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11.5
+        cache: 'pip'
 
     - name: Create Python virtual environment
       run: python3 -m venv dbt-env

--- a/3_tests/immo/input/assert_one_price_mutation.sql
+++ b/3_tests/immo/input/assert_one_price_mutation.sql
@@ -10,8 +10,12 @@ WITH mutation_values AS (
         latitude,
         longitude,
         valeur_fonciere
-    FROM 
+    FROM
+    {% if target.name == 'production' %}
         {{ source('sources', 'dvf_2023')}} as dvf_2023
+    {% else %}
+        {{ source('sources', 'dvf_2023_dev')}} as dvf_2023
+    {% endif %}
 ),
 
 mutation_value_counts AS (

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ CREATE EXTENSION postgis;
 - Extraire les données sources dans le schema `sources`:
 
 ```
-python -m load # -> environ 20 min
+python -m load # -> environ 5 min, uniquement un échantillon de données
+python -m load --production # -> environ 20 min, toutes les données
 ```
 
 

--- a/load/__main__.py
+++ b/load/__main__.py
@@ -3,6 +3,7 @@ This module runs extraction of data from the sources defined in the sources.yml 
 """
 import yaml
 import os
+import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
@@ -14,6 +15,7 @@ from load.loaders import load_file_from_storage, load_file_to_pg,\
 STORAGE_TO_PG = "storage_to_pg.yml"
 
 if __name__ == "__main__":
+    production = '--production' in sys.argv
 
     with open(Path(os.path.dirname(__file__)) / STORAGE_TO_PG, "r") as ymlfile:
         storage_to_pg = yaml.safe_load(ymlfile)
@@ -24,8 +26,12 @@ if __name__ == "__main__":
         
         if pg_table in tables_in_pg_list:
             print(f"Table already exist: {pg_table}")
-        
+
+        elif not production and data_infos.get('production', False):
+            print(f"Skipping {pg_table} in non-production mode")
+
         else:
+            print(f"Processing {pg_table}")
             if data_infos['file_format'] in ['csv', 'json']:
                 with NamedTemporaryFile(suffix='.csv', delete=True) as tmpfile:
                     tmpfile_csv_path = tmpfile.name

--- a/load/storage_to_pg.yml
+++ b/load/storage_to_pg.yml
@@ -35,66 +35,77 @@ dvf_2014:
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2015:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2015/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2016:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2016/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2017:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2017/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2018:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2018/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2019:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2019/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2020:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2020/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2021:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2021/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2022:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2022/full.csv"
   csv_delimiter : ","
   db_schema : "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2023:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2023/full.csv"
   csv_delimiter: ","
   db_schema: "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2024:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2023/full.csv"
   csv_delimiter: ","
   db_schema: "sources"
   file_format: 'csv'
+  production: true
 
 dvf_2014_dev:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/dvf_2014_dev/34.csv"
@@ -167,8 +178,15 @@ logement_2020:
   csv_delimiter: ";"
   db_schema: "sources"
   file_format: 'csv'
+  production: true
 
-professionels_sante: 
+logement_2020_dev:
+  storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/logement_2020_dev/logement_2020_dev.csv"
+  csv_delimiter: ","
+  db_schema: "sources"
+  file_format: 'csv'
+
+professionels_sante:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/professionels_sante/demographie-effectifs-et-les-densites.csv"
   csv_delimiter: ";"
   db_schema: "sources"
@@ -177,12 +195,6 @@ professionels_sante:
 effectif_pathologie:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/effectif_pathologie/effectifs.csv"
   csv_delimiter: ";"
-  db_schema: "sources"
-  file_format: 'csv'
-
-logement_2020_dev:
-  storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/logement_2020_dev/logement_2020_dev.csv"
-  csv_delimiter: ","
   db_schema: "sources"
   file_format: 'csv'
 


### PR DESCRIPTION
Many improvements in CI, in random order:
- Update actions to remove nodejs version warnings
- Add pip cache (shave off 5 seconds)
- Have optional `--production` flag for the load stage (load takes ~5m instead of ~15m)
- Use `dbt build` instead of seed+run+test
- Use a service for postgres in CI => no need to access secrets
- Run over 4 threads in CI

Complete CI run now does not need an external database, and runs in ~10 minutes