### PR TITLE
Feature/add seveso sites

### DIFF
--- a/1_data/prepare/risques/schema.yml
+++ b/1_data/prepare/risques/schema.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+- name: sites_seveso
+  description: |
+    Sites classés SEVESO distingués selon deux types d'établissements, selon la quantité totale de matières dangereuses sur site : 
+    les établissements SEVESO seuil haut et les établissements SEVESO seuil bas. 
+    Données seulement France Métropolitaine.
+  columns:
+  - name: "longitude"
+    description: "Longitude du point"
+    data_type: numeric
+    tests:
+      - not_null
+  - name: "latitude"
+    description: "Latitude du point"
+    data_type: numeric
+    tests:
+      - not_null
+  - name: "point"
+    description: "Point centre de l'établissement SEVESO"
+    data_type: geometry
+    tests:
+      - not_null
+  - name: "id_site"
+    description: "Identifiant unique du site"
+    data_type: string
+    tests:
+      - not_null
+      - unique
+  - name: "nom_site"
+    description: "Nom de l'établissement"
+    data_type: string
+  - name: "id_national_incremental"
+    description: "Numéro serial attribué en France pour chaque site"
+    data_type: string
+  - name: "nom_de_rue"
+    description: "Nom de la rue"
+    data_type: string
+  - name: "code_postal"
+    description: "Code postal"
+    data_type: string
+  - name: "ville"
+    description: "Ville"
+    data_type: string
+  - name: "statut_exploitation"
+    description: |
+      Si le site est en exploitation ou fini. 
+      Un site peut être en cours d'exploitation sans titre SEVESO (changement d'activité). 
+    data_type: string
+  - name: "type_activite"
+    description: "Activité industrielle du site"
+    data_type: string
+  - name: "id_seuil"
+    description: |
+      Niveau de dangerosité du site.
+      1 : haut ; 2 : bas
+    data_type: integer
+  - name: "nom_seuil"
+    description: "Nom de la dangerosité du seuil"
+    data_type: string

--- a/1_data/prepare/risques/sites_seveso.sql
+++ b/1_data/prepare/risques/sites_seveso.sql
@@ -1,0 +1,23 @@
+{{ config(materialized='table') }}
+
+WITH seveso_sites AS (
+    SELECT * FROM {{  source('sources', 'seveso_2024') }}
+),
+renamed_columns AS (
+    SELECT
+        longitude::numeric as longitude,
+        latitude::numeric as latitude,
+        ST_SETSRID(ST_MAKEPOINT(longitude::numeric, latitude::numeric), 4326) as point,
+        identifier as id_site,
+        name as nom_site,
+        localid as id_national_incremental,
+        streetname as nom_de_rue,
+        postalcode as code_postal,
+        city as ville,
+        status as statut_exploitation,
+        activity as type_activite,
+        id_lex_aiot_seveso::integer as id_seuil,
+        type as nom_seuil
+    FROM seveso_sites
+)
+SELECT * FROM renamed_columns

--- a/1_data/sources/schema.yml
+++ b/1_data/sources/schema.yml
@@ -775,3 +775,5 @@ Recensement de la population - Fichier détail. Producteur des données: INSEE. 
       - name: dvf_2024
         description: "Demande de Valeurs Foncières 2024 Géolocalisée par Etalab"
         columns: *shared_columns_dvf_default
+      - name: seveso_2024
+        description: todo

--- a/1_data/sources/schema.yml
+++ b/1_data/sources/schema.yml
@@ -776,4 +776,4 @@ Recensement de la population - Fichier détail. Producteur des données: INSEE. 
         description: "Demande de Valeurs Foncières 2024 Géolocalisée par Etalab"
         columns: *shared_columns_dvf_default
       - name: seveso_2024
-        description: todo
+        description: "Localisation et dangerosité des sites SEVESO en France métropolitaine."

--- a/extract/source_to_storage.yml
+++ b/extract/source_to_storage.yml
@@ -61,3 +61,17 @@ filosofi_commune_2021:
   source_url: https://www.insee.fr/fr/statistiques/fichier/7756729/base-cc-filosofi-2021-geo2024_csv.zip
   source_reference : https://www.insee.fr/fr/statistiques/7756729?sommaire=7756859
 
+
+seveso_sites_2024:
+  source_url: https://mapsref.brgm.fr/wxs/georisques/seveso?&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities
+  source_reference: https://www.data.gouv.fr/fr/datasets/etablissements-seveso-france-metropolitaine-3/
+  description: |
+    The data is exported as [WFS](https://www.ogc.org/publications/standard/wfs/),
+    a XML containing data as Layers.
+    To export it into a csv, it was loaded in QGIS 
+    (Layer>Add Layer>Add WFS Layer ; click New, enter URL, click connect, select layers),
+    then exported into a CSV
+    (select, right click, Export>Save features as ; select csv, all fields, 
+    select 'Geometry'.'Geometry type'='Point', select 'Layer Options'.'GEOMETRY'.'AS_XY').
+    Rename the 'X' column to 'longitude' and 'Y' to 'latitude'.
+    You now have a CSV file with for each Seveso site in France, their identifier, their location and their severity type.

--- a/load/storage_to_pg.yml
+++ b/load/storage_to_pg.yml
@@ -232,3 +232,9 @@ shape_epci_2024:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/shape_files/EPCI.zip"
   db_schema: "sources"
   file_format: 'shape'
+
+seveso_2024:
+  storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/georisques_seveso_france_metropolitaine_2024/georisques-seveso-france-metropolitaine-2024.csv"
+  csv_delimiter: ","
+  db_schema: "sources"
+  file_format: 'csv'


### PR DESCRIPTION
Les sites SEVESO sont des sites industriels avec un risque d'accident majeur.
Il existe deux niveaux de dangerosité: seuil bas et seuil haut. Le calcul du seuil prend en compte les types de comburant stockés ainsi que leurs quantités.
Savoir où sont ces sites permettrait de voir quelles populations sont à risque et de croiser avec des données de santé.
Les données sont référencées sur `data.gouv.fr` mais ont subies une transformation manuelle pour être stockées en csv.