### PR TITLE
Gestion automatique du délimiteur pour les fichiers json

### DIFF
--- a/load/loaders.py
+++ b/load/loaders.py
@@ -71,7 +71,15 @@ def get_columns_from_csv(file_path, delimiter):
     return df.columns.tolist()
 
 
-def load_file_to_pg(tmpfile_csv_path, pg_table, data_infos):
+def load_file_to_pg(tmpfile_csv_path:str, pg_table:str, data_infos):
+    """
+    Load a temporary csv file and feed it to the DB as a new table.
+
+    arguments:
+    tmpfile_csv_path -- path to the temporary file created by load_file_from_storage
+    pg_table -- name of the table to create
+    data_infos -- dict of metadata, loaded from storage_to_pg.yml
+    """
 
     db_schema = data_infos["db_schema"]
     delimiter = data_infos["csv_delimiter"] if data_infos["file_format"] == 'csv' else ','

--- a/load/loaders.py
+++ b/load/loaders.py
@@ -74,7 +74,7 @@ def get_columns_from_csv(file_path, delimiter):
 def load_file_to_pg(tmpfile_csv_path, pg_table, data_infos):
 
     db_schema = data_infos["db_schema"]
-    delimiter = data_infos["csv_delimiter"]
+    delimiter = data_infos["csv_delimiter"] if data_infos["file_format"] == 'csv' else ','
 
     file_columns = get_columns_from_csv(tmpfile_csv_path, delimiter)
     file_columns_str = ', '.join(f'"{col}"' for col in file_columns)

--- a/load/storage_to_pg.yml
+++ b/load/storage_to_pg.yml
@@ -15,25 +15,21 @@ cog_poste:
 
 cog_communes:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/cog_communes/communes.json"
-  csv_delimiter: ","
   db_schema: "sources"
   file_format: 'json'
 
 cog_arrondissements: 
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/cog_arrondissements/arrondissements.json"
-  csv_delimiter: ","
   db_schema: "sources"
   file_format: 'json'
 
 cog_departements:
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/cog_departements/departements.json"
-  csv_delimiter: ","
   db_schema: "sources"
   file_format: 'json'
 
 cog_regions: 
   storage_path: "https://make-open-data-s3.fra1.digitaloceanspaces.com/cog_regions/regions.json"
-  csv_delimiter: ","
   db_schema: "sources"
   file_format: 'json'
 

--- a/load/storage_to_pg.yml
+++ b/load/storage_to_pg.yml
@@ -4,7 +4,7 @@
 #   storage_path:str  # The url to the raw file
 #   db_schema:str  # The name of the schema in the database
 #   file_format:str  # ['csv' | 'json' | 'shape'] The format of the file 
-#   csv_delimiter:str  # If file_format is 'csv' or 'json': the delimiter used in the csv (including temporary csv for json)
+#   csv_delimiter:str  # If file_format is 'csv': the delimiter used in the csv. Ignored if the format is different.
 #   production:bool  # Optional: Whether the file should only be loaded when loading the full base (production mode)
 
 cog_poste:


### PR DESCRIPTION
Actuellement, le format de `load/storage_to_pg.yml` attend un délimiteur csv pour les fichiers json.
- Il est impossible d'ajouter une entrée json sans spécifier ce délimiteur, ce qui est contre-intuitif.
- Un délimiteur renseigné avec autre chose qu'une virgule cause des problèmes au chargement du fichier csv temporaire.

Cette PR supprime ce paramètre pour les fichiers json et le règle automatiquement.