### PR TITLE
creation infos_scot - Fixes #181

### DIFF
--- a/1_data/prepare/geographie/infos_scot.sql
+++ b/1_data/prepare/geographie/infos_scot.sql
@@ -37,9 +37,38 @@ select
     -- Région (on suppose qu'un SCOT n'est que sur une seule région)
     MIN(code_region) as code_region,
     MIN(nom_region) as nom_region,
-    -- Département unique ou NULL si plusieurs
-    CASE WHEN COUNT(DISTINCT code_departement) = 1 THEN MIN(code_departement) ELSE NULL END as code_departement,
-    CASE WHEN COUNT(DISTINCT nom_departement) = 1 THEN MIN(nom_departement) ELSE NULL END as nom_departement,
+    -- Département principal :
+    -- Si un seul département, on prend ce département, sinon celui avec le plus d'habitants
+    (
+        CASE 
+            WHEN COUNT(DISTINCT code_departement) = 1 THEN MIN(code_departement)
+            ELSE (
+                SELECT code_departement FROM (
+                    SELECT code_departement, SUM(CAST(population AS NUMERIC)) as pop
+                    FROM scot_communes sc2
+                    WHERE sc2.scot_code = scot_communes.scot_code
+                    GROUP BY code_departement
+                    ORDER BY pop DESC NULLS LAST
+                    LIMIT 1
+                ) t
+            )
+        END
+    ) as code_departement,
+    (
+        CASE 
+            WHEN COUNT(DISTINCT nom_departement) = 1 THEN MIN(nom_departement)
+            ELSE (
+                SELECT nom_departement FROM (
+                    SELECT nom_departement, SUM(CAST(population AS NUMERIC)) as pop
+                    FROM scot_communes sc2
+                    WHERE sc2.scot_code = scot_communes.scot_code
+                    GROUP BY nom_departement
+                    ORDER BY pop DESC NULLS LAST
+                    LIMIT 1
+                ) t
+            )
+        END
+    ) as main_departement,
     -- Booléen multi_dpt
     (COUNT(DISTINCT code_departement) > 1) as multi_dpt,
     SUM(CAST(population AS NUMERIC)) as population,

--- a/1_data/prepare/geographie/infos_scot.sql
+++ b/1_data/prepare/geographie/infos_scot.sql
@@ -1,0 +1,50 @@
+-- Table: infos_scot
+-- Reports basic infos on SCOT (Schéma de Cohérence Territoriale)
+-- scot_code, siren, scot_name, population, contour, number_of_communes
+
+{{ config(materialized='table') }}
+
+WITH scot_data as (
+    select
+        commune_scot."Id SCoT" as scot_code, -- identifiant unique du SCOT
+        commune_scot."SCoT" as scot_name,    -- nom du SCOT
+        commune_scot."SIREN EPCI" as siren,
+        LPAD(CAST(commune_scot."INSEE commune" AS TEXT), 5, '0') as code_commune
+    from {{ source('sources', 'communes_to_scot') }} as commune_scot
+),
+
+scot_communes as (
+    select 
+        sd.scot_code,
+        sd.siren,
+        sd.scot_name,
+        sd.code_commune,
+        ic.population,
+        ic.commune_contour,
+        ic.code_departement,
+        ic.nom_departement,
+        ic.code_region,
+        ic.nom_region
+    from scot_data sd
+    left join {{ ref('infos_communes') }} ic
+        on sd.code_commune = ic.code_commune
+)
+
+select
+    scot_code,
+    siren,
+    scot_name,
+    -- Région (on suppose qu'un SCOT n'est que sur une seule région)
+    MIN(code_region) as code_region,
+    MIN(nom_region) as nom_region,
+    -- Département unique ou NULL si plusieurs
+    CASE WHEN COUNT(DISTINCT code_departement) = 1 THEN MIN(code_departement) ELSE NULL END as code_departement,
+    CASE WHEN COUNT(DISTINCT nom_departement) = 1 THEN MIN(nom_departement) ELSE NULL END as nom_departement,
+    -- Booléen multi_dpt
+    (COUNT(DISTINCT code_departement) > 1) as multi_dpt,
+    SUM(CAST(population AS NUMERIC)) as population,
+    ST_Union(commune_contour) as contour,
+    COUNT(code_commune) as number_of_communes
+from scot_communes
+where code_commune is not null
+GROUP BY scot_code, siren, scot_name

--- a/1_data/prepare/geographie/schema.yml
+++ b/1_data/prepare/geographie/schema.yml
@@ -104,17 +104,32 @@ models:
       data_type: geometry
       
 - name: infos_scot
-  description: 'Table synthétique rapportant les informations principales sur chaque SCoT (Schéma de Cohérence Territoriale) : code, siren, nom, population totale, contour géographique agrégé, nombre de communes.'
+  description: 'Table synthétique rapportant les informations principales sur chaque SCoT (Schéma de Cohérence Territoriale) : code, siren, nom, région, département (si unique), multi_dpt, population totale, contour géographique agrégé, nombre de communes.'
   columns:
     - name: scot_code
-      description: 'Code du SCoT'
+      description: 'Identifiant unique du SCoT'
       data_type: string
     - name: siren
-      description: 'SIREN SCoT'
+      description: 'SIREN du SCoT'
       data_type: string
     - name: scot_name
       description: 'Nom du SCoT'
       data_type: string
+    - name: code_region
+      description: 'Code de la region du SCoT'
+      data_type: string
+    - name: nom_region
+      description: 'Nom de la region du SCoT'
+      data_type: string
+    - name: code_departement
+      description: 'Code du departement si unique, NULL sinon'
+      data_type: string
+    - name: nom_departement
+      description: 'Nom du departement si unique, NULL sinon'
+      data_type: string
+    - name: multi_dpt
+      description: 'Booleen : true si le SCoT couvre plusieurs départements, false sinon'
+      data_type: boolean
     - name: population
       description: 'Population totale du SCoT'
       data_type: numeric

--- a/1_data/prepare/geographie/schema.yml
+++ b/1_data/prepare/geographie/schema.yml
@@ -103,3 +103,24 @@ models:
       description: "contour géographique du département"
       data_type: geometry
       
+- name: infos_scot
+  description: 'Table synthétique rapportant les informations principales sur chaque SCoT (Schéma de Cohérence Territoriale) : code, siren, nom, population totale, contour géographique agrégé, nombre de communes.'
+  columns:
+    - name: scot_code
+      description: 'Code du SCoT'
+      data_type: string
+    - name: siren
+      description: 'SIREN SCoT'
+      data_type: string
+    - name: scot_name
+      description: 'Nom du SCoT'
+      data_type: string
+    - name: population
+      description: 'Population totale du SCoT'
+      data_type: numeric
+    - name: contour
+      description: 'Contour géographique du SCoT (union des contours des communes)'
+      data_type: geometry
+    - name: number_of_communes
+      description: 'Nombre de communes dans le SCoT'
+      data_type: integer

--- a/1_data/prepare/geographie/schema.yml
+++ b/1_data/prepare/geographie/schema.yml
@@ -109,6 +109,9 @@ models:
     - name: scot_code
       description: 'Identifiant unique du SCoT'
       data_type: string
+      tests:
+          - unique
+          - not_null
     - name: siren
       description: 'SIREN du SCoT'
       data_type: string


### PR DESCRIPTION
Fichier infos_scot.sql ajouté

Prépare la table prepare.infos_scot aec les informations suivantes
- code scot
- nom scot
- siren
- code région
- nom région
- code département
- nom département
- multi_dpt (booleen true si plusieurs departments)
- population
- contour
- nombre de villes

Fichier geographie/schema.yml ajouté pour inclure description de la table infos_scot ainsi que noms de colonnes et description

A noter : 11 lignes avec valeur null dans contour et 76 scot multi départements avec les données dispo au moment du test

Fixes #181